### PR TITLE
Switch to using Variables for everything

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -58,10 +58,10 @@ module "key_vault" {
   name                        = "Wolff-KV-${var.prefix}"
   location                    = var.location
   resource_group_name         = module.resource_group.name
-  enabled_for_disk_encryption = true
+  enabled_for_disk_encryption = var.disk_encryption
   soft_delete_retention_days  = 7
-  purge_protection_enabled    = false
-  sku_name                    = "standard"
+  purge_protection_enabled    = var.purge_protection
+  sku_name                    = var.kv_sku
 }
 
 # Recovery Services Vault
@@ -70,9 +70,9 @@ resource "azurerm_recovery_services_vault" "rsv" {
   name                = "Wolff-RSV-${var.prefix}"
   location            = module.resource_group.location
   resource_group_name = module.resource_group.name
-  sku                 = "Standard"
+  sku                 = var.rsv_sku
 
-  soft_delete_enabled = false
+  soft_delete_enabled = var.soft_delete
 
   tags = var.tags
 

--- a/main.tf
+++ b/main.tf
@@ -29,40 +29,19 @@ resource "azurerm_network_security_group" "nsg" {
   resource_group_name = module.resource_group.name
   tags                = var.tags
 
-  security_rule {
-    name                       = "AllowAzureLoadBalancer"
-    priority                   = 100
-    direction                  = "Inbound"
-    access                     = "Allow"
-    protocol                   = "*"
-    source_port_range          = "*"
-    destination_port_range     = "*"
-    source_address_prefix      = "AzureLoadBalancer"
-    destination_address_prefix = "VirtualNetwork"
-  }
-
-  security_rule {
-    name                       = "AllowSSH"
-    priority                   = 120
-    direction                  = "Inbound"
-    access                     = "Allow"
-    protocol                   = "Tcp"
-    source_port_range          = "*"
-    destination_port_range     = "22"
-    source_address_prefix      = "*"
-    destination_address_prefix = "*"
-  }
-
-  security_rule {
-    name                       = "AllowHTTP"
-    priority                   = 130
-    direction                  = "Inbound"
-    access                     = "Allow"
-    protocol                   = "Tcp"
-    source_port_range          = "*"
-    destination_port_range     = "80"
-    source_address_prefix      = "*"
-    destination_address_prefix = "*"
+  dynamic "security_rule" {
+    for_each = var.nsg_security_rules
+    content {
+      name                       = security_rule.value.name
+      priority                   = security_rule.value.priority
+      direction                  = security_rule.value.direction
+      access                     = security_rule.value.access
+      protocol                   = security_rule.value.protocol
+      source_port_range          = security_rule.value.source_port_range
+      destination_port_range     = security_rule.value.destination_port_range
+      source_address_prefix      = security_rule.value.source_address_prefix
+      destination_address_prefix = security_rule.value.destination_address_prefix
+    }
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -146,7 +146,7 @@ resource "tls_private_key" "tlspk" {
 module "linux_vms" {
   source              = "./modules/linux_vm"
   vm_count            = var.linux_machine_count
-  vm_name             = "Wolff-LinuxVM"
+  vm_name             = var.linux_vm_name
   location            = module.resource_group.location
   resource_group_name = module.resource_group.name
   vm_size             = var.vm_size

--- a/main.tf
+++ b/main.tf
@@ -93,7 +93,7 @@ resource "azurerm_backup_policy_vm" "abp" {
   }
 
   retention_daily {
-   count = var.backp_policy.retention_daily_count
+    count = var.backup_policy.retention_daily_count
   }
 }
 
@@ -184,7 +184,7 @@ resource "azurerm_network_interface" "nic_windowsvm_1" {
 }
 
 resource "azurerm_windows_virtual_machine" "windowsvm_1" {
-  name                = "Wolff-WindowsVM"
+  name                = "${var.windows_vm.name}-${var.prefix}"
   resource_group_name = module.resource_group.name
   location            = module.resource_group.location
   size                = var.vm_size
@@ -196,15 +196,15 @@ resource "azurerm_windows_virtual_machine" "windowsvm_1" {
   ]
 
   os_disk {
-    caching              = "ReadWrite"
-    storage_account_type = "Standard_LRS"
+    caching              = var.windows_vm.caching
+    storage_account_type = var.windows_vm.storage_account_type
   }
 
   source_image_reference {
-    publisher = "MicrosoftWindowsServer"
-    offer     = "WindowsServer"
-    sku       = "2016-Datacenter"
-    version   = "latest"
+    publisher = var.windows_vm.image_publisher
+    offer     = var.windows_vm.image_offer
+    sku       = var.windows_vm.image_sku
+    version   = var.windows_vm.image_version
   }
 
   tags = var.tags

--- a/main.tf
+++ b/main.tf
@@ -81,19 +81,19 @@ resource "azurerm_recovery_services_vault" "rsv" {
 # Backup Policy
 
 resource "azurerm_backup_policy_vm" "abp" {
-  name                = "tfex-recovery-vault-policy"
+  name                = "${var.backup_policy.name}-${var.prefix}"
   resource_group_name = module.resource_group.name
   recovery_vault_name = azurerm_recovery_services_vault.rsv.name
 
-  timezone = "UTC"
+  timezone = var.backup_policy.timezone
 
   backup {
-    frequency = "Daily"
-    time      = "23:00"
+    frequency = var.backup_policy.frequency
+    time      = var.backup_policy.time
   }
 
   retention_daily {
-    count = 7
+   count = var.backp_policy.retention_daily_count
   }
 }
 

--- a/modules/load_balancer/variables.tf
+++ b/modules/load_balancer/variables.tf
@@ -26,26 +26,31 @@ variable "backend_port" {
 }
 
 variable "probe_protocol" {
-  type    = string
-  default = "Http"
+  description = "Protocol to use for the health probe (Http or Tcp)"
+  type        = string
+  default     = "Http"
 }
 
 variable "probe_port" {
-  type    = number
-  default = 80
+  description = "Port number that the health probe will use to check service availability"
+  type        = number
+  default     = 80
 }
 
 variable "probe_interval" {
-  type    = number
-  default = 15
+  description = "Interval in seconds between probe attempts"
+  type        = number
+  default     = 15
 }
 
 variable "probe_unhealthy_threshold" {
-  type    = number
-  default = 2
+  description = "Number of consecutive probe failures before considering the endpoint unhealthy"
+  type        = number
+  default     = 2
 }
 
 variable "probe_request_path" {
-  type    = string
-  default = "/"
+  description = "URI path for HTTP health probe requests"
+  type        = string
+  default     = "/"
 }

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -76,6 +76,16 @@ vm_size             = "Standard_B1ms"
 login_name          = "adminuser"
 linux_machine_count = 2
 
+windows_vm = {
+  name                 = "Wolff-Win"
+  caching              = "ReadWrite"
+  storage_account_type = "Standard_LRS"
+  image_publisher      = "MicrosoftWindowsServer"
+  image_offer          = "WindowsServer"
+  image_sku            = "2016-Datacenter"
+  image_version        = "latest"
+}
+
 # Backup Policy
 
 backup_policy = {

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -26,6 +26,42 @@ subnet_map = {
   "Jumpbox" = ["10.0.3.0/24"]
 }
 
+nsg_security_rules = [
+  {
+    name                       = "AllowAzureLoadBalancer"
+    priority                   = 100
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "*"
+    source_port_range          = "*"
+    destination_port_range     = "*"
+    source_address_prefix      = "AzureLoadBalancer"
+    destination_address_prefix = "VirtualNetwork"
+  },
+  {
+    name                       = "AllowHTTP"
+    priority                   = 110
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "80"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  },
+  {
+    name                       = "AllowSSH"
+    priority                   = 120
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "22"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+]
+
 # Health Probe
 
 probe_protocol            = "Http"

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -75,6 +75,7 @@ probe_request_path        = "/"
 vm_size             = "Standard_B1ms"
 login_name          = "adminuser"
 linux_machine_count = 2
+linux_vm_name = "Wolff-LinuxVM"
 
 windows_vm = {
   name                 = "Wolff-Win"

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -68,10 +68,20 @@ probe_protocol            = "Http"
 probe_port                = 80
 probe_interval            = 15
 probe_unhealthy_threshold = 2
-probe_request_path         = "/"
+probe_request_path        = "/"
 
 # VMs
 
-vm_size    = "Standard_B1ms"
-login_name = "adminuser"
+vm_size             = "Standard_B1ms"
+login_name          = "adminuser"
 linux_machine_count = 2
+
+# Backup Policy
+
+backup_policy = {
+  name                  = "Wolff-ABP"
+  timezone              = "UTC"
+  frequency             = "Daily"
+  time                  = "23:00"
+  retention_daily_count = 7
+}

--- a/variables.tf
+++ b/variables.tf
@@ -106,3 +106,18 @@ variable "linux_machine_count" {
   type        = number
   default     = 2
 }
+
+variable "nsg_security_rules" {
+  description = "List of security rules for the Network Security Group"
+  type = list(object({
+    name                       = string
+    priority                   = number
+    direction                  = string
+    access                     = string
+    protocol                   = string
+    source_port_range          = string
+    destination_port_range     = string
+    source_address_prefix      = string
+    destination_address_prefix = string
+  }))
+}

--- a/variables.tf
+++ b/variables.tf
@@ -132,3 +132,16 @@ variable "backup_policy" {
     retention_daily_count = number
   })
 }
+
+variable "windows_vm" {
+  description = "Configuration for the Windows VM"
+  type = object({
+    name                 = string
+    caching              = string
+    storage_account_type = string
+    image_publisher      = string
+    image_offer          = string
+    image_sku            = string
+    image_version        = string
+  })
+}

--- a/variables.tf
+++ b/variables.tf
@@ -121,3 +121,14 @@ variable "nsg_security_rules" {
     destination_address_prefix = string
   }))
 }
+
+variable "backup_policy" {
+  description = "Configuration for the VM backup policy"
+  type = object({
+    name                  = string
+    timezone              = string
+    frequency             = string
+    time                  = string
+    retention_daily_count = number
+  })
+}

--- a/variables.tf
+++ b/variables.tf
@@ -107,6 +107,11 @@ variable "linux_machine_count" {
   default     = 2
 }
 
+variable "linux_vm_name" {
+  description = "Name to use for Linux VMs"
+  type        = string
+}
+
 variable "nsg_security_rules" {
   description = "List of security rules for the Network Security Group"
   type = list(object({

--- a/variables.tf
+++ b/variables.tf
@@ -72,28 +72,33 @@ variable "pass_min_numeric" {
 }
 
 variable "probe_protocol" {
-  type    = string
-  default = "Http"
+  description = "Protocol to use for the health probe (Http or Tcp)"
+  type        = string
+  default     = "Http"
 }
 
 variable "probe_port" {
-  type    = number
-  default = 80
+  description = "Port number that the health probe will use to check service availability"
+  type        = number
+  default     = 80
 }
 
 variable "probe_interval" {
-  type    = number
-  default = 15
+  description = "Interval in seconds between probe attempts"
+  type        = number
+  default     = 15
 }
 
 variable "probe_unhealthy_threshold" {
-  type    = number
-  default = 2
+  description = "Number of consecutive probe failures before considering the endpoint unhealthy"
+  type        = number
+  default     = 2
 }
 
 variable "probe_request_path" {
-  type    = string
-  default = "/"
+  description = "URI path for HTTP health probe requests"
+  type        = string
+  default     = "/"
 }
 
 variable "linux_machine_count" {

--- a/variables.tf
+++ b/variables.tf
@@ -112,6 +112,36 @@ variable "linux_vm_name" {
   type        = string
 }
 
+variable "disk_encryption" {
+  description = "Global disk encryption setting"
+  type        = bool
+  default     = true
+}
+
+variable "kv_sku" {
+  description = "SKU to use for the key vault"
+  type        = string
+  default     = "standard"
+}
+
+variable "rsv_sku" {
+  description = "SKU to use for the Recovery Services Vault"
+  type = string
+  default = "Standard"
+}
+
+variable "purge_protection" {
+  description = "Global purge protection setting"
+  type        = bool
+  default     = false
+}
+
+variable "soft_delete" {
+  description = "Global soft delete setting"
+  type        = bool
+  default     = false
+}
+
 variable "nsg_security_rules" {
   description = "List of security rules for the Network Security Group"
   type = list(object({


### PR DESCRIPTION
Switch to using variables for basically everything where it makes sense.

- **fix: Add descriptions to variables missing them**
- **fix: Use vars for creating network security rules**
- **fix: Switch backup policy to using variables**
- **fix: Switch Windows VM to using variables**
- **fix: Add variable to use for linux vm name**
- **fix: Create variables for key vault and rsv**
